### PR TITLE
docs: update vscode configuration template

### DIFF
--- a/advanced/debugging.md
+++ b/advanced/debugging.md
@@ -20,22 +20,24 @@ You need to be using Electron 1.8 or later for this launch config to work.
 If you are using &lt; 1.8 you should really be updating Electron anyway.
 {% endhint %}
 
-{% code title="launch.config" %}
-```javascript
+{% code title="launch.json" %}
+```json
 {
-  "type": "node",
-  "request": "launch",
-  "name": "Electron Main",
-  "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge-vscode-nix",
-  "windows": {
-    "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge-vscode-win.cmd"
-  },
-  // runtimeArgs will be passed directly to your Electron application
-  "runtimeArgs": [
-    "foo",
-    "bar"
-  ],
-  "cwd": "${workspaceFolder}"
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Main Process",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge-vscode-nix",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge-vscode-win.cmd"
+      },
+      "runtimeArgs": [],
+      "cwd": "${workspaceFolder}",
+      "timeout": 60000
+    }
+  ]
 }
 ```
 {% endcode %}


### PR DESCRIPTION
It's unlikely for a project with a good amount of code and a transpilation step (i.e. ts + webpack) that the point where the debugger can attach is beyond the vscode default timeout.  To get it working I had to add this.


Additionally passing "foo" and "bar" by default configuration, although seemingly obvious, is just an unnecessary thing to have to delete.  I think either it's removed or keep it empty like above.   Also I'm not totally sure but I believe the standard debugging file is now `launch.json` and allows multiple configurations of which this can be one of.