### PR TITLE
docs: add Google Cloud Storage publisher docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,6 +35,7 @@
   * [GitHub](config/publishers/github.md)
   * [Nucleus](config/publishers/nucleus.md)
   * [S3](config/publishers/s3.md)
+  * [GCS](config/publishers/gcs.md)
   * [Snapcraft](config/publishers/snapcraft.md)
 
 ## Advanced

--- a/config/publishers/gcs.md
+++ b/config/publishers/gcs.md
@@ -1,13 +1,17 @@
 # Google Cloud Storage
 
+{% hint style="info" %}
+This publish target was added in Electron Forge 7.1.0.
+{% endhint %}
+
 The Google Cloud Storage (GCS) target publishes all your artifacts to a [Google Cloud Storage bucket](https://cloud.google.com/storage/docs), nothing fancy here, literally just puts all your artifacts straight into the bucket.
 
 {% hint style="warning" %}
 If you run publish twice with the same version on the same platform it is possible for your old artifacts to get overwritten in Storage.  It is your responsibility to ensure that you don't overwrite your own releases.
 {% endhint %}
 
-By default all files are positioned at the following key:  
-  
+By default all files are positioned at the following key:
+
 `${config.folder || version}/${artifactName}`
 
 Configuration options are documented in [`PublisherGCSConfig`](https://js.electronforge.io/publisher/gcs/interfaces/publishergcsconfig.html)

--- a/config/publishers/gcs.md
+++ b/config/publishers/gcs.md
@@ -1,0 +1,27 @@
+# Google Cloud Storage
+
+The Google Cloud Storage (GCS) target publishes all your artifacts to a [Google Cloud Storage bucket](https://cloud.google.com/storage/docs), nothing fancy here, literally just puts all your artifacts straight into the bucket.
+
+{% hint style="warning" %}
+If you run publish twice with the same version on the same platform it is possible for your old artifacts to get overwritten in Storage.  It is your responsibility to ensure that you don't overwrite your own releases.
+{% endhint %}
+
+By default all files are positioned at the following key:  
+  
+`${config.folder || version}/${artifactName}`
+
+Configuration options are documented in [`PublisherGCSConfig`](https://js.electronforge.io/publisher/gcs/interfaces/publishergcsconfig.html)
+
+### Usage
+
+```javascript
+{
+  name: '@electron-forge/publisher-gcs',
+  config: {
+    bucket: 'my-bucket',
+    public: true
+  }
+}
+```
+
+It is recommended to authenticate by providing path to JSON file that contains your Google service account credentials by environment variable `GOOGLE_APPLICATION_CREDENTIALS`.


### PR DESCRIPTION
Documentation for: https://github.com/electron-userland/electron-forge/pull/1752