### PR TITLE
Add "rs" to restart app to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm start
 {% endtab %}
 {% endtabs %}
 
+### Restarting the app while Electron Forge is running
+
+When your app is running you can type `rs` and press Enter to restart your app. This is especially useful if you have edited your main Electron process behaviour.
+
 ## Building Distributables
 
 So you've got an **amazing** application there, and you want to package it all up and share it with the world.  If you run the `make` script Electron Forge will generate you platform specific distributables for you to share with everyone.  For more information on what kind of distributables you can make, check out the [Makers ](config/makers/)documentation.


### PR DESCRIPTION
Hi! We're using the Electron Forge Webpack plugin and our application takes some time to build. It's really helpful to be able to restart the entire application without having to start Webpack.

I found [in the source code](https://github.com/electron-userland/electron-forge/blob/8613386dee43de30f709a489a7ed9aa0474234de/packages/api/core/src/api/start.ts#L142) that you can type `rs` on stdin to restart Electron, which is exactly what we needed! It doesn't seem to be documented anywhere so I'd like to suggest adding it to the section on "The Basics".

--

Edit: An example of this in use for those wondering how it works:

```shell
electron-forge start
```

Then type `rs` and press Enter.

![image](https://user-images.githubusercontent.com/292958/90391798-a2832f80-e085-11ea-8ec3-d084611ec858.png)
