### PR TITLE
Fix error on npx using repo

### DIFF
--- a/import-existing-project.md
+++ b/import-existing-project.md
@@ -18,7 +18,8 @@ yarn electron-forge import
 {% tab title="NPM" %}
 ```bash
 cd my-app
-npx @electron-forge/cli import
+npm i -D @electron-forge/cli
+npx electron-forge import
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
No matter what I did, I always received this message when executing `npx @electron-forge/cli import`:

![image](https://user-images.githubusercontent.com/3200560/97356167-a1853000-1876-11eb-80e8-cabbcd02d043.png)

I tested it out with local and global installations, and it worked fine. I think this is not the root cause of the issue, probably there's something wrong with the bin link, but this change will prevent others to have the same error as me.