### PR TITLE
Typo fix in yarn command example

### DIFF
--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -15,7 +15,7 @@ npx create-electron-app my-new-app --template=typescript-webpack
 
 {% tab title="Yarn" %}
 ```
-yarn create electron-app my-new-app --template=typescript-webpack
+yarn create-electron-app my-new-app --template=typescript-webpack
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The previous version missed a dash (-) in yarn command example, it should be `yarn create-electron-app` instead of `yarn create electron-app`