### PR TITLE
Update label for link to Nucleus docs

### DIFF
--- a/config/publishers/nucleus.md
+++ b/config/publishers/nucleus.md
@@ -1,6 +1,6 @@
 # Nucleus
 
-The Nucleus target publishes all your artifacts to an instance of Nucleus Update Server, this update service supports all three platforms.  Check out the README at [`atlassian/github`](https://github.com/atlassian/nucleus) for more information on this project.
+The Nucleus target publishes all your artifacts to an instance of Nucleus Update Server, this update service supports all three platforms.  Check out the README at [`atlassian/nucleus`](https://github.com/atlassian/nucleus) for more information on this project.
 
 Configuration options are documented in [`PublisherNucleusConfig`](https://js.electronforge.io/publisher/nucleus/interfaces/publishernucleusconfig.html)
 


### PR DESCRIPTION
The old label looks like it was a mistype or something