### PR TITLE
Update documentation - change tslint to eslint

### DIFF
--- a/templates/typescript-template.md
+++ b/templates/typescript-template.md
@@ -4,7 +4,7 @@ description: Create a new Electron app with TypeScript.
 
 # TypeScript
 
-To get you up and running as fast as possible with [TypeScript](https://www.typescriptlang.org/) and Electron, we have provided a basic template that utilizes `tsc` and `tslint`.
+To get you up and running as fast as possible with [TypeScript](https://www.typescriptlang.org/) and Electron, we have provided a basic template that utilizes `tsc` and `eslint`.
 
 {% tabs %}
 {% tab title="NPM" %}


### PR DESCRIPTION
Documentation indicates that the template uses `tslint`, but this was updated to `eslint` in electron-userland/electron-forge#1467.