### PR TITLE
Small tweak in react integration guide

### DIFF
--- a/guides/framework-integration/react-with-typescript.md
+++ b/guides/framework-integration/react-with-typescript.md
@@ -60,5 +60,25 @@ import './app';
 {% endtab %}
 {% endtabs %}
 
+### Fix ESLint rules
+
+Let ESLint know `.tsx` files can be imported as module by editing `.eslintrc.json` file. Add this option :
+
+```json
+"settings": {
+  "import/resolver": {
+    "node": {
+      "extensions": [
+        ".js",
+        ".json",
+        ".ts",
+        ".tsx"
+      ]
+    }
+  }
+}
+
+```
+
 For more about React, see [their documentation](https://reactjs.org/docs/hello-world.html).
 


### PR DESCRIPTION
Without this tweak, `import './app'` in the `renderer.ts` file yield ESLint error `Unable to resolve path to module './app' .eslintimport/no-unresolved`.

Cf https://stackoverflow.com/questions/65578102/import-local-file-not-resolved/65579426#65579426 for original issue