### PR TITLE
Added missing commas in `config/publishers/README.md`

### DIFF
--- a/config/publishers/README.md
+++ b/config/publishers/README.md
@@ -9,8 +9,8 @@ Each publisher has to be configured in the `publishers` section of your Forge co
 module.exports = {
   publishers: [
     {
-      name: '@electron-forge/publisher-s3'
-      platforms: ['darwin', 'linux']
+      name: '@electron-forge/publisher-s3',
+      platforms: ['darwin', 'linux'],
       config: {
         bucket: 'my-bucket',
         folder: 'my/key/prefix'


### PR DESCRIPTION
Hello,

Just added two missing commas in `config/publishers/README.md`.
The configuration snippet is now ready to be copy-pasted without errors!