### PR TITLE
Remove return from example

### DIFF
--- a/config/makers/squirrel.windows.md
+++ b/config/makers/squirrel.windows.md
@@ -34,7 +34,7 @@ The easiest way to handle these arguments and stop your app launching multiple t
 ```javascript
 const { app } = require('electron');
 
-if (require('electron-squirrel-startup')) return app.quit();
+if (require('electron-squirrel-startup')) app.quit();
 ```
 {% endcode %}
 


### PR DESCRIPTION
Received this when making my app after using the provided example:
```
Module parse failed: 'return' outside of function (11:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|
| if (require('electron-squirrel-startup')) {
>   return app.quit();
| }

```