### PR TITLE
docs: fix broken links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -57,5 +57,5 @@
   * [Writing Templates](advanced/extending-electron-forge/writing-templates.md)
   * [Writing Makers](advanced/extending-electron-forge/writing-makers.md)
   * [Writing Publishers](advanced/extending-electron-forge/writing-publishers.md)
-* [API Docs](https://js.electronforge.io/api/core)
+* [API Docs](https://js.electronforge.io/modules/_electron_forge_core.html)
 

--- a/advanced/extending-electron-forge/writing-makers.md
+++ b/advanced/extending-electron-forge/writing-makers.md
@@ -2,7 +2,7 @@
 
 An Electron Forge Maker has to export a single class that extends our base maker. The base maker can be depended on by installing`@electron-forge/maker-base`.
 
-The `MakerBase` class has some helper methods for your convenience. Check out the interface of [`MakerBase`](https://js.electronforge.io/maker/base/classes/maker.html) for more advanced API details.
+The `MakerBase` class has some helper methods for your convenience. Check out the interface of [`MakerBase`](https://js.electronforge.io/classes/_electron_forge_maker_base.Maker.html) for more advanced API details.
 
 | Method | Description |
 | :--- | :--- |
@@ -34,7 +34,7 @@ Makers must implement this method and return an array of **absolute** paths to t
 
 The `config` for the maker will be available on `this.config`.
 
-The options object is documented in [`MakerOptions`](https://js.electronforge.io/maker/base/interfaces/makeroptions.html).
+The options object is documented in [`MakerOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_base.MakerOptions.html).
 
 ```javascript
 export default class MyMaker extends MakerBase {

--- a/advanced/extending-electron-forge/writing-plugins.md
+++ b/advanced/extending-electron-forge/writing-plugins.md
@@ -30,7 +30,7 @@ If implemented, this method will be called every time the user runs `electron-fo
 Please note that overriding the start logic here only works in **development** if you want to change how an app runs once packaged you will need to use a build hook to inject code into the packaged app.
 
 {% hint style="info" %}
-`StartOptions`is explained further [in the API docs](https://js.electronforge.io/utils/types/interfaces/startoptions).
+`StartOptions`is explained further [in the API docs](https://js.electronforge.io/interfaces/_electron_forge_shared_types.StartOptions.html).
 {% endhint %}
 
 ```javascript

--- a/advanced/extending-electron-forge/writing-publishers.md
+++ b/advanced/extending-electron-forge/writing-publishers.md
@@ -2,7 +2,7 @@
 
 An Electron Forge Publisher has to export a single class that extends the base publisher. The base plugin can be depended on by installing`@electron-forge/publisher-base`.
 
-Check out the interface of [`PublisherBase`](https://js.electronforge.io/publisher/base/classes/publisher.html) for more advanced API details.
+Check out the interface of [`PublisherBase`](https://js.electronforge.io/modules/_electron_forge_publisher_base.html) for more advanced API details.
 
 The publisher **must** implement one method:
 
@@ -14,7 +14,7 @@ Please note for a given version, publish will be called multiple times, once for
 
 The `config` for the publisher will be available on `this.config` .
 
-The options object is documented in [`PublisherOptions`](https://js.electronforge.io/publisher/base/interfaces/publisheroptions.html) 
+The options object is documented in [`PublisherOptions`](https://js.electronforge.io/interfaces/_electron_forge_publisher_base.PublisherOptions.html) 
 
 ```javascript
 export default class MyPublisher extends PublisherBase {

--- a/cli.md
+++ b/cli.md
@@ -24,7 +24,7 @@ npm install --save-dev @electron-forge/cli
 
 ## Overview
 
-At a high level the CLI module is just a proxy to the raw [API](https://js.electronforge.io) commands.  Almost all the configuration is still done in your [Forge configuration](configuration.md), the CLI just provides a handy way to trigger all the core functionality of Electron Forge.
+At a high level the CLI module is just a proxy to the raw [API](https://js.electronforge.io/classes/_electron_forge_core.ForgeAPI.html) commands.  Almost all the configuration is still done in your [Forge configuration](configuration.md), the CLI just provides a handy way to trigger all the core functionality of Electron Forge.
 
 ## Commands
 

--- a/config/makers/appx.md
+++ b/config/makers/appx.md
@@ -8,7 +8,7 @@ description: >-
 
 The AppX target builds `.appx` packages which are designed to target the Windows Store.  You can only build the AppX target on Windows machines with the Windows 10 SDK installed.  Check the [`electron-windows-store` docs](https://github.com/felixrieseberg/electron-windows-store#readme) for more information on platform requirements.
 
-Configuration options are documented in [`MakerAppXConfig`](https://js.electronforge.io/maker/appx/interfaces/makerappxconfig.html).
+Configuration options are documented in [`MakerAppXConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_appx.MakerAppXConfig.html).
 
 ### Usage
 

--- a/config/makers/deb.md
+++ b/config/makers/deb.md
@@ -8,7 +8,7 @@ description: >-
 
 The deb target builds [`.deb` packages](https://en.wikipedia.org/wiki/Deb_%28file_format%29), which are the standard package format for Debian-based Linux distributions such as Ubuntu.  You can only build the deb target on Linux or macOS machines with the `fakeroot` and `dpkg` packages installed.
 
-Configuration options are documented in [`MakerDebConfig`](https://js.electronforge.io/maker/deb/interfaces/makerdebconfig.html).
+Configuration options are documented in [`MakerDebConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_deb.MakerDebConfig.html).
 
 ### Usage
 

--- a/config/makers/dmg.md
+++ b/config/makers/dmg.md
@@ -10,7 +10,7 @@ The DMG target builds `.dmg` files, which are the standard format for sharing ma
 You can only build the DMG target on macOS machines.
 {% endhint %}
 
-Configuration options are documented in [`MakerDMGConfig`](https://js.electronforge.io/maker/dmg/interfaces/makerdmgconfig.html).
+Configuration options are documented in [`MakerDMGConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_dmg.MakerDMGConfig.html).
 
 ### Usage
 

--- a/config/makers/flatpak.md
+++ b/config/makers/flatpak.md
@@ -8,7 +8,7 @@ The Flatpak target builds [`.flatpak` files](http://flatpak.org/), which is a pa
 
 You can only build the Flatpak target if you have `flatpak`, `flatpak-builder`, and `eu-strip` _\(usually part of the `elfutils` package\)_ installed on your system.
 
-Configuration options are documented in [`MakerFlatpakConfig`](https://js.electronforge.io/maker/flatpak/interfaces/makerflatpakconfig.html).
+Configuration options are documented in [`MakerFlatpakConfig`](https://js.electronforge.io/classes/_electron_forge_maker_flatpak.MakerFlatpak-1.html#config).
 
 ### Usage
 

--- a/config/makers/pkg.md
+++ b/config/makers/pkg.md
@@ -6,7 +6,7 @@ description: Create a PKG file for your Electron app on macOS using Electron For
 
 The Pkg target builds `.pkg` files for macOS. These are used to upload your application to the Mac App Store or just as an alternate distribution method for macOS users.  You can only build the Pkg target on macOS machines while targeting the `darwin`  or `mas` platforms.
 
-Configuration options are documented in [`MakerPkgConfig`](https://js.electronforge.io/maker/pkg/interfaces/makerpkgconfig.html).
+Configuration options are documented in [`MakerPkgConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_pkg.MakerPKGConfig.html).
 
 ### Usage
 

--- a/config/makers/rpm.md
+++ b/config/makers/rpm.md
@@ -10,7 +10,7 @@ The RPM target builds `.rpm` files, which is the standard package format for Red
 
 You can only build the RPM target on Linux machines with the `rpm` or `rpm-build` packages installed.
 
-Configuration options are documented in [`MakerRpmConfig`](https://js.electronforge.io/maker/rpm/interfaces/makerrpmconfig.html).
+Configuration options are documented in [`MakerRpmConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_rpm.MakerRpmConfig.html).
 
 ### Usage
 

--- a/config/makers/snapcraft.md
+++ b/config/makers/snapcraft.md
@@ -8,7 +8,7 @@ The Snapcraft target builds `.snap` files, which is the packaging format created
 
 You can only build the Snapcraft target on Linux systems with the [`snapcraft`](https://snapcraft.io/) package installed.
 
-Configuration options are documented in [`MakerSnapConfig`](https://js.electronforge.io/maker/snap/interfaces/makersnapconfig.html).
+Configuration options are documented in [`MakerSnapConfig`](https://js.electronforge.io/modules/_electron_forge_maker_snap.html#MakerSnapConfig).
 
 ## Usage
 

--- a/config/makers/squirrel.windows.md
+++ b/config/makers/squirrel.windows.md
@@ -8,7 +8,7 @@ The Squirrel.Windows target builds a number of files required to distribute apps
 
 Squirrel.Windows is a no-prompt, no-hassle, no-admin method of installing Windows applications and is therefore the most user friendly you can get. You can only build the Squirrel.Windows target on a Windows machine or on a macOS /Linux machine with `mono` and `wine` installed.
 
-Configuration options are documented in [`MakerSquirrelConfig`](https://js.electronforge.io/maker/squirrel/interfaces/makersquirrelconfig.html).
+Configuration options are documented in [`MakerSquirrelConfig`](https://js.electronforge.io/modules/_electron_forge_maker_squirrel.html#MakerSquirrelConfig).
 
 ## Usage
 

--- a/config/plugins/auto-unpack-natives.md
+++ b/config/plugins/auto-unpack-natives.md
@@ -12,7 +12,7 @@ yarn add @electron-forge/plugin-auto-unpack-natives --dev
 
 You must add this plugin to your [`plugins`](../../configuration.md#plugins) array in your forge config
 
-The complete config options are available at [`AutoUnpackNativesConfig`](https://js.electronforge.io/plugin/auto-unpack-natives/interfaces/autounpacknativesconfig.html). 
+The complete config options are available at [`AutoUnpackNativesConfig`](https://js.electronforge.io/interfaces/_electron_forge_plugin_auto_unpack_natives.AutoUnpackNativesConfig.html). 
 
 {% code title="forge.config.js" %}
 ```javascript

--- a/config/plugins/local-electron.md
+++ b/config/plugins/local-electron.md
@@ -22,5 +22,5 @@ This plugin allows you to both run and package/make your app using a **local** b
 
 ### Configuration
 
-All possible configuration options are documented in [`LocalElectronPluginConfig`](https://js.electronforge.io/plugin/local-electron/interfaces/localelectronpluginconfig.html).  Please note that all paths must be absolute, you should use `path.resolve()` to make things deterministic.
+All possible configuration options are documented in [`LocalElectronPluginConfig`](https://js.electronforge.io/interfaces/_electron_forge_plugin_local_electron.LocalElectronPluginConfig.html).  Please note that all paths must be absolute, you should use `path.resolve()` to make things deterministic.
 

--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -26,7 +26,7 @@ npm install --save-dev @electron-forge/plugin-webpack
 
 ### Configuration
 
-You must provide two Webpack config files: one for the main process in `mainConfig`, and one for the renderer process in `renderer.config`. The complete config options are available at [`WebpackPluginConfig`](https://js.electronforge.io/plugin/webpack/interfaces/webpackpluginconfig.html). For example, in your [Forge configuration](../../configuration.md):
+You must provide two Webpack config files: one for the main process in `mainConfig`, and one for the renderer process in `renderer.config`. The complete config options are available at [`WebpackPluginConfig`](https://js.electronforge.io/interfaces/_electron_forge_plugin_webpack.WebpackPluginConfig.html). For example, in your [Forge configuration](../../configuration.md):
 
 {% tabs %}
 {% tab title="package.json" %}

--- a/config/publishers/bitbucket.md
+++ b/config/publishers/bitbucket.md
@@ -10,7 +10,7 @@ description: >-
 This publish target is for [Bitbucket Cloud](https://bitbucket.org) only and will not work with self hosted Bitbucket Server instances.
 {% endhint %}
 
-Full configuration options are documented in [`PublisherBitbucketConfig`](https://js.electronforge.io/publisher/bitbucket/interfaces/publisherbitbucketconfig).
+Full configuration options are documented in [`PublisherBitbucketConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_bitbucket.PublisherBitbucketConfig.html).
 
 ## Usage
 

--- a/config/publishers/github.md
+++ b/config/publishers/github.md
@@ -2,7 +2,7 @@
 
 The GitHub target publishes all your artifacts to GitHub releases, this allows your users to download the files straight from your repository or if your repository is open source you can use [update.electronjs.org](https://github.com/electron/update.electronjs.org) and get a free hosted update service.
 
-Configuration options are documented in [`PublisherGitHubConfig`](https://js.electronforge.io/publisher/github/interfaces/publishergithubconfig.html)
+Configuration options are documented in [`PublisherGitHubConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_github.PublisherGitHubConfig.html)
 
 {% hint style="info" %}
 You can use this target to publish to GitHub Enterprise using the host configuration options of `octokitOptions`. Check out the configuration options linked above.

--- a/config/publishers/nucleus.md
+++ b/config/publishers/nucleus.md
@@ -2,7 +2,7 @@
 
 The Nucleus target publishes all your artifacts to an instance of Nucleus Update Server, this update service supports all three platforms. Check out the README at [`atlassian/nucleus`](https://github.com/atlassian/nucleus) for more information on this project.
 
-Configuration options are documented in [`PublisherNucleusConfig`](https://js.electronforge.io/publisher/nucleus/interfaces/publishernucleusconfig.html)
+Configuration options are documented in [`PublisherNucleusConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_nucleus.PublisherNucleusConfig.html)
 
 {% hint style="warning" %}
 We recommend you set the `token` option using an environment variable, don't hard code it into your config

--- a/config/publishers/s3.md
+++ b/config/publishers/s3.md
@@ -14,7 +14,7 @@ By default, all files are positioned at the following key:\
 \
 `${config.folder || appVersion}/${artifactName}`
 
-Configuration options are documented in [`PublisherS3Config`](https://js.electronforge.io/publisher/s3/interfaces/publishers3config.html).
+Configuration options are documented in [`PublisherS3Config`](https://js.electronforge.io/interfaces/_electron_forge_publisher_s3.PublisherS3Config.html).
 
 ### Authentication
 

--- a/config/publishers/snapcraft.md
+++ b/config/publishers/snapcraft.md
@@ -4,7 +4,7 @@ The Snapcraft target publishes your `.snap` artifacts to the [Snap Store](https:
 
 This target requires that the system has the `snapcraft` utility installed.
 
-Configuration options are documented in [`PublisherSnapConfig`](https://js.electronforge.io/publisher/snapcraft/interfaces/publishersnapcraftconfig.html)
+Configuration options are documented in [`PublisherSnapConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_snapcraft.PublisherSnapcraftConfig.html)
 
 ### Usage
 

--- a/configuration.md
+++ b/configuration.md
@@ -199,7 +199,7 @@ This hook is called before the `make` step runs.
 
 #### `postMake`
 
-This hook is called after the `make` step has successfully completed. It is passed a single argument which is an array of [`MakeResult`](https://js.electronforge.io/utils/types/interfaces/forgemakeresult.html) objects, if your hooks wishes to modify those make results it must return a new array of [`MakeResult`](https://js.electronforge.io/utils/types/interfaces/forgemakeresult) objects that Electron Forge can use from then on.
+This hook is called after the `make` step has successfully completed. It is passed a single argument which is an array of [`MakeResult`](https://js.electronforge.io/interfaces/_electron_forge_shared_types.ForgeMakeResult.html) objects, if your hooks wishes to modify those make results it must return a new array of [`MakeResult`](https://js.electronforge.io/interfaces/_electron_forge_shared_types.ForgeMakeResult.html) objects that Electron Forge can use from then on.
 
 #### `readPackageJson`
 


### PR DESCRIPTION
fixed links to ts generated docs as their urls changed


issue: https://github.com/electron-forge/electron-forge-docs/issues/69