### PR TITLE
Typo in auto-unpack-natives documentation

### DIFF
--- a/config/plugins/auto-unpack-natives.md
+++ b/config/plugins/auto-unpack-natives.md
@@ -1,6 +1,6 @@
 # Auto Unpack Native Modules
 
-This plugin will automatically add all native modules in your `node_modules` folder to the [`asar.unpack`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#asar) config option in your [`packagerConfig`](../../configuration.md#packager-config).  If you have any native modules as all you should probably use this to reduce loading times and disk consumption on your users' machines.
+This plugin will automatically add all native modules in your `node_modules` folder to the [`asar.unpack`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#asar) config option in your [`packagerConfig`](../../configuration.md#packager-config).  If you have any native modules at all you should probably use this to reduce loading times and disk consumption on your users' machines.
 
 ## Installation
 


### PR DESCRIPTION
The word `as` should be `at` in  "If you have any native modules at all you should probably use this to reduce loading times and disk consumption on your users' machines."