### PR TITLE
docs: add instructions for wix installer icon

### DIFF
--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -14,7 +14,8 @@ If you want to support different displays with different DPI densities at the sa
 
 ```txt
 images/
-├── icon.png
+├── 
+.png
 ├── icon@2x.png
 └── icon@3x.png
 ```
@@ -117,7 +118,7 @@ config: {
             {
                 name: "@electron-forge/maker-wix",
                 config: {
-                    appIconPath: "/path/to/icon.ico"
+                    icon: "/path/to/icon.ico"
                 }
             },
             {

--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -115,6 +115,12 @@ config: {
                 }
             },
             {
+                name: "@electron-forge/maker-wix",
+                config: {
+                    appIconPath: "/path/to/icon.ico"
+                }
+            },
+            {
                 // Path to a single image that will act as icon for the application
                 name: "@electron-forge/maker-deb",
                 config: {


### PR DESCRIPTION
issue: github.com/felixrieseberg/electron-wix-msi/issues/99

we should have documentation on how to set up installer icons for maker-wix