### PR TITLE
docs: add webpack caching instructions

### DIFF
--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -80,6 +80,28 @@ module.exports = {
 
 The above configuration is the default for the [Webpack template](../../templates/webpack-template.md).
 
+### Caching
+When using Webpack 5 caching, asset permissions need to be maintained through their own cache, and the public path needs to be injected into the build. 
+
+To insure these cases work out, make sure to run `initAssetCache` in the build, with the `options.outputAssetBase` argument:
+```js
+const relocateLoader = require('@vercel/webpack-asset-relocator-loader');
+
+webpack({
+  // ...
+
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.compilation.tap("webpack-asset-relocator-loader", compilation => {
+          relocateLoader.initAssetCache(compilation, outputAssetBase);
+        });
+      }
+    }
+  ]
+});
+```
+
 #### Node integration
 
 {% hint style="info" %}

--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -115,6 +115,12 @@ config: {
                 }
             },
             {
+                name: "@electron-forge/maker-wix",
+                config: {
+                    appIconPath: "/path/to/icon.ico"
+                }
+            },
+            {
                 // Path to a single image that will act as icon for the application
                 name: "@electron-forge/maker-deb",
                 config: {

--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -115,12 +115,6 @@ config: {
                 }
             },
             {
-                name: "@electron-forge/maker-wix",
-                config: {
-                    appIconPath: "/path/to/icon.ico"
-                }
-            },
-            {
                 // Path to a single image that will act as icon for the application
                 name: "@electron-forge/maker-deb",
                 config: {


### PR DESCRIPTION
issue: https://github.com/electron-userland/electron-forge/issues/2412

adding this code into the webpack plugin config will avoid hot reload problems related to webpack 5 caching behaviour. 

