### PR TITLE
docs: fix link to icon guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -43,7 +43,7 @@
 * [Code Signing](guides/code-signing/README.md)
   * [macOS](guides/code-signing/code-signing-macOS.md)
   * [Windows](guides/code-signing/code-signing-windows.md)
-* [Creating and Setting App Icons](create-and-add-icons.md)
+* [Creating and Setting App Icons](guides/create-and-add-icons.md)
 * [Framework Integration](guides/framework-integration/README.md)
   * [Parcel](guides/framework-integration/parcel.md)
   * [React](guides/framework-integration/react.md)


### PR DESCRIPTION
broken link in summary.md