### PR TITLE
docs: fix missing "maintainer" field in makers/rpm usage example

### DIFF
--- a/config/makers/rpm.md
+++ b/config/makers/rpm.md
@@ -33,7 +33,6 @@ Configuration options are documented in [`MakerRpmConfig`](https://js.electronfo
   name: '@electron-forge/maker-rpm',
   config: {
     options: {
-      maintainer: 'Joe Bloggs',
       homepage: 'http://example.com'
     }
   }


### PR DESCRIPTION
Remove the `options.maintainer` field from the usage example on the [Makers/RPM](https://www.electronforge.io/config/makers/rpm) page. The [`MakerRpmConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_rpm.MakerRpmConfig.html) does not contain an `options.maintainer` field, but the current usage example suggests that this field is available.