### PR TITLE
fix(react): update imports for React 18

### DIFF
--- a/guides/framework-integration/react-with-typescript.md
+++ b/guides/framework-integration/react-with-typescript.md
@@ -7,7 +7,7 @@ description: 'How to create an Electron app with React, TypeScript, and Electron
 Adding React support to the TypeScript + Webpack template is fairly straightforward and doesn't require a complicated boilerplate to get started.
 
 {% hint style="info" %}
-The following guide has been tested with React 17, TypeScript 4.3, and Webpack 5.
+The following guide has been tested with React 18, TypeScript 4.3, and Webpack 5.
 {% endhint %}
 
 ### Create the app and setup the TypeScript config
@@ -41,13 +41,10 @@ You should now be able to start writing and using React components in your Elect
 {% tabs %}
 {% tab title="src/app.tsx" %}
 ```tsx
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-function render() {
-  ReactDOM.render(<h2>Hello from React!</h2>, document.body);
-}
-
-render();
+const root = createRoot(document.body);
+root.render(<h2>Hello from React!</h2>);
 ```
 {% endtab %}
 

--- a/guides/framework-integration/react.md
+++ b/guides/framework-integration/react.md
@@ -7,7 +7,7 @@ description: How to create an Electron app with React and Electron Forge
 Adding React support to the Webpack template doesn't require a complicated boilerplate to get started.
 
 {% hint style="info" %}
-The following guide has been tested with React 17, Babel 7, and Webpack 5.
+The following guide has been tested with React 18, Babel 7, and Webpack 5.
 {% endhint %}
 
 ### Create the app and setup the Webpack config
@@ -75,13 +75,10 @@ You should now be able to start writing and using React components in your Elect
 {% tab title="src/app.jsx" %}
 ```jsx
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-function render() {
-  ReactDOM.render(<h2>Hello from React!</h2>, document.body);
-}
-
-render();
+const root = createRoot(document.body);
+root.render(<h2>Hello from React!</h2>);
 ```
 {% endtab %}
 


### PR DESCRIPTION
Closes #89

current code snippet still works but throw an js error.

Changed snippets to new client rendering API.

React Upgrade Docs:
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis