### PR TITLE
fix: add missing comma in `osxNotarize` options

### DIFF
--- a/guides/code-signing/code-signing-macos.md
+++ b/guides/code-signing/code-signing-macos.md
@@ -230,7 +230,7 @@ module.exports = {
     osxSign: {},
     osxNotarize: {
       tool: 'notarytool',
-      appleId: process.env.APPLE_ID
+      appleId: process.env.APPLE_ID,
       appleIdPassword: process.env.APPLE_PASSWORD,
       teamId: process.env.APPLE_TEAM_ID
     },


### PR DESCRIPTION
added a comma to osxNotarize