### PR TITLE
build: fix lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - main
+      - v6
   workflow_dispatch:
     inputs:
       fetch-external-links:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@dsanders11/markdown-linting/configs/markdownlint.json",
+  "extends": "@electron/lint-roller/configs/markdownlint.json",
   "blanks-around-fences": false,
   "no-multiple-blanks": false
 }


### PR DESCRIPTION
Follow-up to #103, the new workflow didn't actually run in that PR since it is from a fork, and this slipped through the cracks.