### PR TITLE
build: lint JS in Markdown

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,8 @@ jobs:
       run: npm install --save-dev @electron/lint-roller
     - name: Run markdownlint
       run: npx electron-markdownlint "**/*.md"
+    - name: Lint JS in Markdown with standard
+      run: npx electron-lint-markdown-standard --root . --ignore-path .markdownlintignore --semi --fix "**/*.md"
     - name: Lint links
       run: npx electron-lint-markdown-links --root . --ignore-path .markdownlintignore "**/*.md"
       if: ${{ always() }}

--- a/advanced/debugging.md
+++ b/advanced/debugging.md
@@ -21,7 +21,7 @@ If you are using &lt; 1.8 you should really be updating Electron anyway.
 {% endhint %}
 
 {% code title="launch.config" %}
-```json
+```jsonc
 {
   "type": "node",
   "request": "launch",

--- a/advanced/debugging.md
+++ b/advanced/debugging.md
@@ -21,7 +21,7 @@ If you are using &lt; 1.8 you should really be updating Electron anyway.
 {% endhint %}
 
 {% code title="launch.config" %}
-```javascript
+```json
 {
   "type": "node",
   "request": "launch",

--- a/advanced/extending-electron-forge/writing-makers.md
+++ b/advanced/extending-electron-forge/writing-makers.md
@@ -20,11 +20,11 @@ If the issue is a missing dependency you should log out a **helpful** error mess
 
 ```javascript
 export default class MyMaker extends MakerBase {
-  isSupportedOnCurrentPlatform() {
+  isSupportedOnCurrentPlatform () {
     return process.platform === 'linux' && this.isFakeRootInstalled();
   }
-  
-  isFakeRootInstalled() { ... }
+
+  isFakeRootInstalled () { /* ... */ }
 }
 ```
 
@@ -38,7 +38,7 @@ The options object is documented in [`MakerOptions`](https://js.electronforge.io
 
 ```javascript
 export default class MyMaker extends MakerBase {
-  async make(opts) {
+  async make (opts) {
     const pathToMagicInstaller = await makeMagicInstaller(opts.dir);
     return [pathToMagicInstaller];
   }

--- a/advanced/extending-electron-forge/writing-plugins.md
+++ b/advanced/extending-electron-forge/writing-plugins.md
@@ -10,13 +10,13 @@ The possible hook names and the parameters passed to the hook function you retur
 
 ```javascript
 export default class MyPlugin extends PluginBase {
-  getHooks() {
+  getHooks () {
     return {
-      prePackage: [this.prePackage],
+      prePackage: [this.prePackage]
     };
   }
-  
-  prePackage() {
+
+  prePackage () {
     console.log('running prePackage hook');
   }
 }
@@ -34,11 +34,11 @@ Please note that overriding the start logic here only works in **development** i
 
 ```javascript
 export default class MyPlugin extends Pluginbase {
-  async startLogic(opts) {
+  async startLogic (opts) {
     await this.compileMainProcess();
     return null;
   }
-  
-  compileMainProcess() { ... }
+
+  compileMainProcess () { /* ... */ }
 }
 ```

--- a/advanced/extending-electron-forge/writing-publishers.md
+++ b/advanced/extending-electron-forge/writing-publishers.md
@@ -18,7 +18,7 @@ The options object is documented in [`PublisherOptions`](https://js.electronforg
 
 ```javascript
 export default class MyPublisher extends PublisherBase {
-  async publish(opts) {
+  async publish (opts) {
     for (const result of opts.makeResults) {
       await createVersionIfNotExists();
       await uploadDistributable(result);

--- a/cli.md
+++ b/cli.md
@@ -263,8 +263,8 @@ const { api } = require('@electron-forge/core');
 const main = async () => {
   await api.package({
     // add package command options here
-  })
-}
+  });
+};
 
 main();
 ```

--- a/config/configuration.md
+++ b/config/configuration.md
@@ -71,7 +71,7 @@ module.exports = {
 {% endtab %}
 
 {% tab title="package.json" %}
-```json
+```jsonc
 // Only the relevant section of package.json is shown, for brevity.
 {
   "config": {

--- a/config/configuration.md
+++ b/config/configuration.md
@@ -22,14 +22,14 @@ module.exports = {
       name: '@electron-forge/maker-zip'
     }
   ]
-}
+};
 ```
 {% endcode %}
 {% endtab %}
 
 {% tab title="package.json" %}
 {% code title="package.json" %}
-```javascript
+```json
 {
   "name": "my-app",
   "version": "0.0.1",
@@ -59,19 +59,19 @@ We recommend using using JavaScript for your config file since it enables condit
 {% tab title="forge.config.js" %}
 ```javascript
 module.exports = {
-  packagerConfig: { ... },
-  rebuildConfig: { ... },
-  makers: [ ... ],
-  publishers: [ ... ],
-  plugins: [ ... ],
-  hooks: { ... },
+  packagerConfig: { /* ... */ },
+  rebuildConfig: { /* ... */ },
+  makers: [],
+  publishers: [],
+  plugins: [],
+  hooks: { /* ... */ },
   buildIdentifier: 'my-build'
-}
+};
 ```
 {% endtab %}
 
 {% tab title="package.json" %}
-```javascript
+```json
 // Only the relevant section of package.json is shown, for brevity.
 {
   "config": {
@@ -145,7 +145,7 @@ module.exports = {
   packagerConfig: {
     appBundleId: fromBuildIdentifier({ beta: 'com.beta.app', prod: 'com.app' })
   }
-}
+};
 ```
 {% endcode %}
 

--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -12,7 +12,7 @@ Each maker has to be configured in the `makers` section of your forge configurat
 
 {% tabs %}
 {% tab title="package.json" %}
-```javascript
+```json
 // If your config is only in package.json:
 // Only showing the relevant configuration for brevity
 {
@@ -26,7 +26,8 @@ Each maker has to be configured in the `makers` section of your forge configurat
               // Config here
           }
         }
-    ]
+      ]
+    }
   }
 }
 ```
@@ -37,16 +38,16 @@ Each maker has to be configured in the `makers` section of your forge configurat
 // If you have set config.forge to a JavaScript file path in package.json:
 // Only showing the relevant configuration for brevity
 module.exports = {
-    makers: [
-        {
-            name: '@electron-forge/maker-zip',
-            platforms: ['darwin', 'linux'],
-            config: {
-                // Config here
-            }
-        }
-    ]
-}
+  makers: [
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin', 'linux'],
+      config: {
+        // Config here
+      }
+    }
+  ]
+};
 ```
 {% endtab %}
 {% endtabs %}

--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -12,7 +12,7 @@ Each maker has to be configured in the `makers` section of your forge configurat
 
 {% tabs %}
 {% tab title="package.json" %}
-```json
+```jsonc
 // If your config is only in package.json:
 // Only showing the relevant configuration for brevity
 {

--- a/config/makers/squirrel.windows.md
+++ b/config/makers/squirrel.windows.md
@@ -47,7 +47,7 @@ Squirrel.Windows requires mandatory package metadata to satisfy the [`.nuspec`](
 By default, the Squirrel.Windows maker fetches the `author` and `description` fields in the  project's package.json file.
 
 {% code title="package.json" %}
-```json
+```jsonc
 {
   // ...
   "author": "Alice and Bob",

--- a/config/makers/squirrel.windows.md
+++ b/config/makers/squirrel.windows.md
@@ -24,10 +24,10 @@ module.exports = {
       name: '@electron-forge/maker-squirrel',
       config: {
         certificateFile: './cert.pfx',
-        certificatePassword: process.env.CERTIFICATE_PASSWORD,
-      },
-    },
-  ],
+        certificatePassword: process.env.CERTIFICATE_PASSWORD
+      }
+    }
+  ]
 };
 ```
 {% endcode %}
@@ -70,10 +70,10 @@ module.exports = {
       config: {
         authors: 'Alice and Bob',
         description: 'An example Electron app'
-      },
-    },
+      }
+    }
   ]
-}
+};
 ```
 {% endcode %}
 

--- a/config/plugins/auto-unpack-natives.md
+++ b/config/plugins/auto-unpack-natives.md
@@ -39,11 +39,11 @@ module.exports = {
     asar: true // or an object containing your asar options
   },
   plugins: [
-   {
-     name: '@electron-forge/plugin-auto-unpack-natives',
-     config: {}
-   }
+    {
+      name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {}
+    }
   ]
-}
+};
 ```
 {% endcode %}

--- a/config/plugins/electronegativity.md
+++ b/config/plugins/electronegativity.md
@@ -33,18 +33,16 @@ Add this plugin to the [`plugins`](../configuration.md#plugins) array in your Fo
 {% code title="forge.config.js" %}
 ```javascript
 module.exports = {
-  //...
-  {
-    plugins: [
-      {
-        name: '@electron-forge/plugin-electronegativity',
-        config: {
-          isSarif: true
-        }
+  // ...
+  plugins: [
+    {
+      name: '@electron-forge/plugin-electronegativity',
+      config: {
+        isSarif: true
       }
-    ]
-  }
-  //...
-}
+    }
+  ]
+  // ...
+};
 ```
 {% endcode %}

--- a/config/plugins/local-electron.md
+++ b/config/plugins/local-electron.md
@@ -41,10 +41,10 @@ All possible configuration options are documented in [`LocalElectronPluginConfig
     {
       name: '@electron-forge/plugin-local-electron',
       config: {
-        electronPath: '/Users/me/projects/electron/out/Testing',
-      },
-    },
-  ],
+        electronPath: '/Users/me/projects/electron/out/Testing'
+      }
+    }
+  ]
 }
 ```
 {% endcode %}

--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -45,22 +45,22 @@ module.exports = {
             // `entry` is an alias for `build.lib.entry`
             // in the corresponding file of `config`.
             entry: 'src/main.js',
-            config: 'vite.main.config.mjs',
+            config: 'vite.main.config.mjs'
           },
           {
             entry: 'src/preload.js',
-            config: 'vite.preload.config.mjs',
-          },
+            config: 'vite.preload.config.mjs'
+          }
         ],
         renderer: [
           {
             name: 'main_window',
-            config: 'vite.renderer.config.mjs',
-          },
-        ],
-      },
-    },
-  ],
+            config: 'vite.renderer.config.mjs'
+          }
+        ]
+      }
+    }
+  ]
 };
 ```
 {% endtab %}
@@ -111,11 +111,11 @@ Vite's build config generates a separate entry for the main process and preload 
 Your `main` entry in your `package.json` file needs to point at `".vite/build/main"`, like so:
 
 {% code title="package.json" %}
-```javascript
+```json
 {
   "name": "my-vite-app",
   "main": ".vite/build/main.js",
-  ...
+  // ...
 }
 ```
 {% endcode %}
@@ -137,10 +137,10 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'serialport',
-        'sqlite3',
-      ],
-    },
-  },
+        'sqlite3'
+      ]
+    }
+  }
 });
 ```
 {% endcode %}
@@ -156,7 +156,7 @@ In the case of the `main_window`, the global variables will be named `MAIN_WINDO
 
 {% code title="main.js" %}
 ```javascript
-const mainWindow = new BrowserWindow({...});
+const mainWindow = new BrowserWindow({ /* ... */ });
 
 if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
   mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);

--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -66,9 +66,9 @@ module.exports = {
 {% endtab %}
 
 {% tab title="package.json" %}
-```json
+```jsonc
 {
-  //...
+  // ...
   "config": {
     "forge": {
       "plugins": [
@@ -96,7 +96,7 @@ module.exports = {
       ]
     }
   }
-  //...
+  // ...
 }
 ```
 {% endtab %}
@@ -111,7 +111,7 @@ Vite's build config generates a separate entry for the main process and preload 
 Your `main` entry in your `package.json` file needs to point at `".vite/build/main"`, like so:
 
 {% code title="package.json" %}
-```json
+```jsonc
 {
   "name": "my-vite-app",
   "main": ".vite/build/main.js",

--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -60,9 +60,9 @@ module.exports = {
 {% endtab %}
 
 {% tab title="package.json" %}
-```json
+```jsonc
 {
-  //...
+  // ...
   "config": {
     "forge": {
       "plugins": [
@@ -86,7 +86,7 @@ module.exports = {
       ]
     }
   }
-  //...
+  // ...
 }
 ```
 {% endtab %}
@@ -103,7 +103,7 @@ You need to do two things in your project files in order to make this plugin wor
 First, your `main` entry in your `package.json` file needs to point at `"./.webpack/main"` like so:
 
 {% code title="package.json" %}
-```json
+```jsonc
 {
   "name": "my-app",
   "main": "./.webpack/main",

--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -34,7 +34,7 @@ For example, this is the [configuration](../configuration.md) taken from Forge's
 {% tab title="forge.config.js" %}
 ```javascript
 module.exports = {
-  //...
+  // ...
   plugins: [
     {
       name: '@electron-forge/plugin-webpack',
@@ -49,13 +49,13 @@ module.exports = {
             preload: {
               js: './src/preload.js'
             }
-          }],
+          }]
         }
       }
     }
   ]
-  //...
-}
+  // ...
+};
 ```
 {% endtab %}
 
@@ -103,11 +103,11 @@ You need to do two things in your project files in order to make this plugin wor
 First, your `main` entry in your `package.json` file needs to point at `"./.webpack/main"` like so:
 
 {% code title="package.json" %}
-```javascript
+```json
 {
   "name": "my-app",
   "main": "./.webpack/main",
-  ...
+  // ...
 }
 ```
 {% endcode %}
@@ -127,7 +127,7 @@ In the case of the `main_window` entry point in the earlier example, the global 
 ```javascript
 const mainWindow = new BrowserWindow({
   webPreferences: {
-    preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+    preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY
   }
 });
 
@@ -155,7 +155,7 @@ ipcMain.on('get-preload-path', (e) => {
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electron', {
-  getPreloadPath: () => ipcRenderer.sendSync('get-preload-path');
+  getPreloadPath: () => ipcRenderer.sendSync('get-preload-path')
 });
 ```
 {% endcode %}
@@ -200,10 +200,10 @@ In development mode, you can change most `webpack-dev-server` options by setting
   config: {
     // other Webpack plugin config...
     devServer: {
-      stats: 'verbose',
-    },
-    //...
-  },
+      stats: 'verbose'
+    }
+    // ...
+  }
 }
 ```
 {% endcode %}
@@ -217,13 +217,13 @@ In development mode, you can set a [Content Security Policy (CSP)](https://devel
   name: '@electron-forge/plugin-webpack',
   config: {
     // other Webpack plugin config...
-    devContentSecurityPolicy: `default-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:`,
+    devContentSecurityPolicy: 'default-src \'self\' \'unsafe-inline\' data:; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data:',
     // other Webpack plugin config...
     mainConfig: './webpack.main.config.js',
     renderer: {
       /* renderer config here, see above section */
-    },
-  },
+    }
+  }
 }
 ```
 
@@ -265,7 +265,7 @@ module.exports = {
         // relocator loader generates a "fake" .node file which is really
         // a cjs file.
         test: /native_modules\/.+\.node$/,
-        use: 'node-loader',
+        use: 'node-loader'
       },
       {
         test: /\.(m?js|node)$/,
@@ -273,13 +273,13 @@ module.exports = {
         use: {
           loader: '@vercel/webpack-asset-relocator-loader',
           options: {
-            outputAssetBase: 'native_modules',
-          },
-        },
-      },
+            outputAssetBase: 'native_modules'
+          }
+        }
+      }
     ]
   }
-}
+};
 ```
 {% endcode %}
 
@@ -294,10 +294,10 @@ In Electron, you can enable Node.js in the renderer process with [`BrowserWindow
 {% code title="main.js (Main Process)" %}
 ```javascript
 const win = new BrowserWindow({
-    webPreferences: {
-        contextIsolation: false,
-        nodeIntegration: true,
-    }
+  webPreferences: {
+    contextIsolation: false,
+    nodeIntegration: true
+  }
 });
 ```
 {% endcode %}
@@ -367,7 +367,7 @@ webpack({
   // ...
   plugins: [
     {
-      apply(compiler) {
+      apply (compiler) {
         compiler.hooks.compilation.tap('webpack-asset-relocator-loader', compilation => {
           relocateLoader.initAssetCache(compilation, outputAssetBase);
         });

--- a/config/publishers/README.md
+++ b/config/publishers/README.md
@@ -17,7 +17,7 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}
 

--- a/config/publishers/bitbucket.md
+++ b/config/publishers/bitbucket.md
@@ -33,8 +33,7 @@ module.exports = {
       }
     }
   ]
-}
-
+};
 ```
 {% endcode %}
 

--- a/config/publishers/electron-release-server.md
+++ b/config/publishers/electron-release-server.md
@@ -22,6 +22,6 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}

--- a/config/publishers/github.md
+++ b/config/publishers/github.md
@@ -26,6 +26,6 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}

--- a/config/publishers/nucleus.md
+++ b/config/publishers/nucleus.md
@@ -25,6 +25,6 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}

--- a/config/publishers/s3.md
+++ b/config/publishers/s3.md
@@ -27,7 +27,7 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}
 
@@ -49,8 +49,8 @@ To avoid this problem, you can use the `keyResolver` option to generate the S3 k
   name: '@electron-forge/publisher-s3',
   config: {
     // ...
-    keyResolver: (fileName: string, platform: string, arch: string) => {
-      return `some-prefix/${platform}/${arch}/filename`;
+    keyResolver: (fileName, platform, arch) => {
+      return `some-prefix/${platform}/${arch}/filename`
     }
     // ...
   }
@@ -58,7 +58,3 @@ To avoid this problem, you can use the `keyResolver` option to generate the S3 k
 ```
 {% endcode %}
 {% endhint %}
-
-
-
-\

--- a/config/publishers/snapcraft.md
+++ b/config/publishers/snapcraft.md
@@ -16,10 +16,10 @@ module.exports = {
     {
       name: '@electron-forge/publisher-snapcraft',
       config: {
-        release: "[latest/edge, insider/stable]"
+        release: '[latest/edge, insider/stable]'
       }
     }
   ]
-}
+};
 ```
 {% endcode %}

--- a/guides/code-signing/code-signing-macos.md
+++ b/guides/code-signing/code-signing-macos.md
@@ -64,7 +64,7 @@ module.exports = {
   packagerConfig: {
     osxSign: {} // object must exist even if empty
   }
-}
+};
 ```
 {% endcode %}
 
@@ -91,12 +91,12 @@ module.exports = {
         // to specific files in your packaged app.
         return {
           entitlements: 'path/to/entitlements.plist'
-        }
+        };
       }
     }
   }
   // ...
-}
+};
 ```
 {% endcode %}
 
@@ -136,18 +136,18 @@ There are two mandatory fields for `osxNotarize` if you are using this strategy:
 {% code title="forge.config.js" %}
 ```javascript
 module.exports = {
-  //...
+  // ...
   packagerConfig: {
     // ...
     osxNotarize: {
       tool: 'notarytool',
       appleId: process.env.APPLE_ID,
       appleIdPassword: process.env.APPLE_PASSWORD,
-      teamId: process.env.APPLE_TEAM_ID,
+      teamId: process.env.APPLE_TEAM_ID
     }
   }
-  //...
-}
+  // ...
+};
 ```
 {% endcode %}
 
@@ -170,18 +170,18 @@ There are three mandatory fields for `osxNotarize` if you are using this strateg
 {% code title="forge.config.js" %}
 ```javascript
 module.exports = {
-  //...
+  // ...
   packagerConfig: {
     // ...
     osxNotarize: {
       tool: 'notarytool',
       appleApiKey: process.env.APPLE_API_KEY,
       appleApiKeyId: process.env.APPLE_API_KEY_ID,
-      appleApiIssuer: process.env.APPLE_API_ISSUER,
+      appleApiIssuer: process.env.APPLE_API_ISSUER
     }
   }
-  //...
-}
+  // ...
+};
 ```
 {% endcode %}
 
@@ -205,17 +205,17 @@ There are two mandatory fields for `osxNotarize` if you are using this strategy:
 {% code title="forge.config.js" %}
 ```javascript
 module.exports = {
-  //...
+  // ...
   packagerConfig: {
     // ...
     osxNotarize: {
       tool: 'notarytool',
       keychain: 'my-keychain',
-      keychainProfile: 'my-keychain-profile',
+      keychainProfile: 'my-keychain-profile'
     }
   }
-  //...
-}
+  // ...
+};
 ```
 {% endcode %}
 
@@ -232,9 +232,9 @@ module.exports = {
       tool: 'notarytool',
       appleId: process.env.APPLE_ID,
       appleIdPassword: process.env.APPLE_PASSWORD,
-      teamId: process.env.APPLE_TEAM_ID,
-    },
-  },
+      teamId: process.env.APPLE_TEAM_ID
+    }
+  }
 };
 ```
 {% endcode %}

--- a/guides/code-signing/code-signing-windows.md
+++ b/guides/code-signing/code-signing-windows.md
@@ -47,6 +47,6 @@ module.exports = {
       }
     }
   ]
-}
+};
 ```
 {% endcode %}

--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -53,7 +53,7 @@ module.exports = {
     icon: '/path/to/icon' // no file extension required
   }
   // ...
-}
+};
 ```
 {% endcode %}
 
@@ -104,7 +104,7 @@ Here is an example of how that can be done:
 ```javascript
 // forge.config.js
 module.exports = {
-  //...
+  // ...
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
@@ -112,35 +112,34 @@ module.exports = {
         // An URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features).
         iconUrl: 'https://url/to/icon.ico',
         // The ICO file to use as the icon for the generated Setup.exe
-        setupIcon: '/path/to/icon.ico',
-      },
+        setupIcon: '/path/to/icon.ico'
+      }
     },
     {
       // Path to a single image that will act as icon for the application
       name: '@electron-forge/maker-deb',
       config: {
         options: {
-          icon: '/path/to/icon.png',
-        },
-      },
+          icon: '/path/to/icon.png'
+        }
+      }
     },
     {
       // Path to the icon to use for the app in the DMG window
       name: '@electron-forge/maker-dmg',
       config: {
-        icon: '/path/to/icon.icns',
-      },
+        icon: '/path/to/icon.icns'
+      }
     },
     {
       name: '@electron-forge/maker-wix',
       config: {
-        icon: '/path/to/icon.ico',
-      },
-    },
-  ],
+        icon: '/path/to/icon.ico'
+      }
+    }
+  ]
   // ...
 };
-
 ```
 
 Once again, once you are done configuring your icons, don't forget to build your project with the Make command.

--- a/guides/framework-integration/react.md
+++ b/guides/framework-integration/react.md
@@ -43,9 +43,9 @@ module.exports = [
         presets: ['@babel/preset-react']
       }
     }
-  },
+  }
   // ... existing loader config ...
-]
+];
 ```
 {% endcode %}
 

--- a/guides/framework-integration/vue-2.md
+++ b/guides/framework-integration/vue-2.md
@@ -58,7 +58,7 @@ const app = new Vue({
   data: {
     message: 'Hello Vue!'
   }
-})
+});
 ```
 {% endtab %}
 {% endtabs %}

--- a/import-existing-project.md
+++ b/import-existing-project.md
@@ -73,7 +73,7 @@ npm install --save-dev @electron-forge/cli @electron-forge/maker-squirrel @elect
 To start using Forge, add a few command scripts to your package.json file:
 
 {% code title="package.json" %}
-```json
+```jsonc
 {
   // ...
   "scripts": {
@@ -89,7 +89,7 @@ To start using Forge, add a few command scripts to your package.json file:
 Then, set up your Forge [configuration.md](config/configuration.md "mention") in the `config.forge` field in package.json.
 
 {% code title="package.json" %}
-```json
+```jsonc
 {
   // ...
   "config": {


### PR DESCRIPTION
Mostly whitespace, semis, and commas, but it did catch a couple of spots where there were mistakes with brackets, and did identify some code blocks that were using `javascript` when they should be using `json` for the language identifier.

Also threw in some changes from `json` to `jsonc` for language identifier when comments were present, as it is still recognized by GitHub and prevents the nasty dark red text background when viewing the code on GitHub.