### PR TITLE
docs: fix broken links

### DIFF
--- a/advanced/extending-electron-forge/writing-makers.md
+++ b/advanced/extending-electron-forge/writing-makers.md
@@ -2,7 +2,7 @@
 
 An Electron Forge Maker has to export a single class that extends our base maker. The base maker can be depended on by installing`@electron-forge/maker-base`.
 
-The `MakerBase` class has some helper methods for your convenience. Check out the interface of [`MakerBase`](https://js.electronforge.io/classes/_electron_forge_maker_base.Maker.html) for more advanced API details.
+The `MakerBase` class has some helper methods for your convenience. Check out the interface of [`MakerBase`](https://js.electronforge.io/classes/_electron_forge_maker_base.MakerBase.html) for more advanced API details.
 
 | Method | Description |
 | :--- | :--- |

--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -289,7 +289,7 @@ If the asset relocator loader does not work for your native module, you may want
 
 #### Enabling Node integration in your app code
 
-In Electron, you can enable Node.js in the renderer process with [`BrowserWindow` constructor options](https://www.electronjs.org/docs/latest/api/browser-window). Renderers with the following options enabled will have a browser-like web environment with access to Node.js [`require`](https://nodejs.org/en/knowledge/getting-started/what-is-require/) and all of its core APIs:
+In Electron, you can enable Node.js in the renderer process with [`BrowserWindow` constructor options](https://www.electronjs.org/docs/latest/api/browser-window). Renderers with the following options enabled will have a browser-like web environment with access to Node.js [`require`](https://nodejs.org/api/modules.html#requireid) and all of its core APIs:
 
 {% code title="main.js (Main Process)" %}
 ```javascript


### PR DESCRIPTION
Detected by manually running the lint workflow with check external links enabled.