### PR TITLE
docs: add tabs for bun package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ yarn create electron-app my-app
 npm init electron-app@latest my-app
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app@latest my-app
+```
+{% endtab %}
 {% endtabs %}
 
 {% hint style="warning" %}
@@ -50,6 +56,12 @@ yarn create electron-app my-app --template=webpack
 {% tab title="npm" %}
 ```bash
 npm init electron-app@latest my-app -- --template=webpack
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app@latest my-app -- --template=webpack
 ```
 {% endtab %}
 {% endtabs %}
@@ -85,6 +97,13 @@ cd my-app
 npm start
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+cd my-app
+bun run start
+```
+{% endtab %}
 {% endtabs %}
 
 ## Building distributables
@@ -103,6 +122,12 @@ yarn make
 npm run make
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun run make
+```
+{% endtab %}
 {% endtabs %}
 
 ## Publishing your app
@@ -119,6 +144,12 @@ yarn run publish
 {% tab title="npm" %}
 ```bash
 npm run publish
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun run publish
 ```
 {% endtab %}
 {% endtabs %}

--- a/cli.md
+++ b/cli.md
@@ -31,6 +31,12 @@ yarn add --dev @electron-forge/cli
 npm install --save-dev @electron-forge/cli
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add --dev @electron-forge/cli
+```
+{% endtab %}
 {% endtabs %}
 
 ## Bootstrap commands
@@ -70,6 +76,12 @@ yarn electron-forge init --template=webpack
 npx electron-forge init --template=webpack
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+npx electron-forge init --template=webpack
+```
+{% endtab %}
 {% endtabs %}
 
 ### Import
@@ -92,6 +104,12 @@ yarn electron-forge import
 {% tab title="npm" %}
 ```bash
 npx electron-forge import
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx electron-forge import
 ```
 {% endtab %}
 {% endtabs %}
@@ -137,6 +155,15 @@ npm run package -- --arch="ia32"
 npx electron-forge package --arch="ia32"
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+# By default, the package command corresponds to a package npm script:
+bun run package -- --arch="ia32"
+# If there is no package script:
+bunx electron-forge package --arch="ia32"
+```
+{% endtab %}
 {% endtabs %}
 
 ### Make
@@ -178,6 +205,15 @@ npm run make -- --arch="ia32"
 npx electron-forge make --arch="ia32"
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+# By default, the make command corresponds to a make npm script:
+bun run make -- --arch="ia32"
+# If there is no make script:
+bunx electron-forge make --arch="ia32"
+```
+{% endtab %}
 {% endtabs %}
 
 Building for ia32 and x64 architectures:
@@ -192,6 +228,12 @@ yarn make --arch="ia32,x64"
 {% tab title="npm" %}
 ```bash
 npm run make -- --arch="ia32,x64"
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun run make --arch="ia32,x64"
 ```
 {% endtab %}
 {% endtabs %}
@@ -228,6 +270,14 @@ yarn electron-forge publish --from-dry-run
 </strong>npm run publish -- --from-dry-run
 # If there is no publish script:
 npx electron-forge publish -- --from-dry-run
+</code></pre>
+{% endtab %}
+
+{% tab title="Bun" %}
+<pre class="language-bash"><code class="lang-bash"><strong># By default, the publish command corresponds to a publish npm script:
+</strong>bun run publish -- --from-dry-run
+# If there is no publish script:
+bunx electron-forge publish -- --from-dry-run
 </code></pre>
 {% endtab %}
 {% endtabs %}
@@ -272,6 +322,15 @@ yarn electron-forge start --enable-logging
 npm start --enable-logging
 # if there is no start script
 npx electron-forge start --enable-logging
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+# By default, the start command corresponds to a start npm script:
+bun run start --enable-logging
+# if there is no start script
+bunx electron-forge start --enable-logging
 ```
 {% endtab %}
 {% endtabs %}

--- a/config/plugins/auto-unpack-natives.md
+++ b/config/plugins/auto-unpack-natives.md
@@ -22,6 +22,12 @@ yarn add --dev @electron-forge/plugin-auto-unpack-natives
 npm install --save-dev @electron-forge/plugin-auto-unpack-natives
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```shell
+bun add --dev @electron-forge/plugin-auto-unpack-natives
+```
+{% endtab %}
 {% endtabs %}
 
 ## Usage

--- a/config/plugins/electronegativity.md
+++ b/config/plugins/electronegativity.md
@@ -22,6 +22,12 @@ yarn add --dev @electron-forge/plugin-electronegativity
 npm install --save-dev @electron-forge/plugin-electronegativity
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```shell
+bun add --dev @electron-forge/plugin-electronegativity
+```
+{% endtab %}
 {% endtabs %}
 
 ## Usage

--- a/config/plugins/local-electron.md
+++ b/config/plugins/local-electron.md
@@ -26,6 +26,12 @@ yarn add --dev @electron-forge/plugin-local-electron
 npm install --save-dev @electron-forge/plugin-local-electron
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add --dev @electron-forge/plugin-local-electron
+```
+{% endtab %}
 {% endtabs %}
 
 ### Usage

--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -20,6 +20,12 @@ yarn add --dev @electron-forge/plugin-vite
 npm install --save-dev @electron-forge/plugin-vite
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```shell
+bun add --dev @electron-forge/plugin-vite
+```
+{% endtab %}
 {% endtabs %}
 
 ## Usage

--- a/config/plugins/webpack.md
+++ b/config/plugins/webpack.md
@@ -20,6 +20,12 @@ yarn add --dev @electron-forge/plugin-webpack
 npm install --save-dev @electron-forge/plugin-webpack
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```shell
+bun add --dev @electron-forge/plugin-webpack
+```
+{% endtab %}
 {% endtabs %}
 
 ## Usage
@@ -247,6 +253,12 @@ yarn add --dev node-loader @vercel/webpack-asset-relocator-loader@1.7.3
 {% tab title="npm" %}
 ```shell
 npm install --save-dev node-loader @vercel/webpack-asset-relocator-loader@1.7.3
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```shell
+bun add --dev node-loader @vercel/webpack-asset-relocator-loader@1.7.3
 ```
 {% endtab %}
 {% endtabs %}

--- a/guides/framework-integration/react-with-typescript.md
+++ b/guides/framework-integration/react-with-typescript.md
@@ -32,6 +32,13 @@ npm install --save react react-dom
 npm install --save-dev @types/react @types/react-dom
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add react react-dom
+bun add --dev @types/react @types/react-dom
+```
+{% endtab %}
 {% endtabs %}
 
 ### Integrate React code

--- a/guides/framework-integration/react.md
+++ b/guides/framework-integration/react.md
@@ -26,6 +26,12 @@ yarn add --dev @babel/core @babel/preset-react babel-loader
 npm install --save-dev @babel/core @babel/preset-react babel-loader
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```text
+bun add --dev @babel/core @babel/preset-react babel-loader
+```
+{% endtab %}
 {% endtabs %}
 
 Set up the [`babel-loader`](https://www.npmjs.com/package/babel-loader)module with the [React preset](https://babeljs.io/docs/en/babel-preset-react) in `webpack.rules.js`:
@@ -63,6 +69,12 @@ yarn add react react-dom
 {% tab title="NPM" %}
 ```bash
 npm install --save react react-dom
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add react react-dom
 ```
 {% endtab %}
 {% endtabs %}

--- a/guides/framework-integration/vue-2.md
+++ b/guides/framework-integration/vue-2.md
@@ -26,6 +26,12 @@ npm install --save vue
 yarn add vue
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add vue
+```
+{% endtab %}
 {% endtabs %}
 
 ### Integrate Vue 2 code
@@ -81,6 +87,12 @@ npm install --save-dev vue-loader vue-template-compiler
 yarn add --dev vue-loader vue-template-compiler
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add --dev vue-loader vue-template-compiler
+```
+{% endtab %}
 {% endtabs %}
 
 Setting up the [`vue-loader` Webpack module](https://vue-loader.vuejs.org/guide/#webpack-configuration) is left as an exercise for the reader _(hint: `vue-loader` Webpack config should ideally go in the renderer configuration only)_.
@@ -97,6 +109,12 @@ npm install --save vue
 {% tab title="Yarn" %}
 ```bash
 yarn add vue
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bun add vue
 ```
 {% endtab %}
 {% endtabs %}

--- a/import-existing-project.md
+++ b/import-existing-project.md
@@ -77,6 +77,13 @@ cd my-app
 npm install --save-dev @electron-forge/cli @electron-forge/maker-squirrel @electron-forge/maker-deb @electron-forge/maker-zip
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+cd my-app
+bun add --dev @electron-forge/cli @electron-forge/maker-squirrel @electron-forge/maker-deb @electron-forge/maker-zip
+```
+{% endtab %}
 {% endtabs %}
 
 ### Configuring package.json
@@ -156,6 +163,13 @@ cd my-app
 npm install electron-squirrel-startup
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+cd my-app
+bun add electron-squirrel-startup
+```
+{% endtab %}
 {% endtabs %}
 
 Then, add the following snippet as early as possible in the main process execution (before the `app.ready` event).
@@ -184,6 +198,13 @@ yarn add --dev @electron-forge/publisher-s3
 ```bash
 cd my-app
 npm install --save-dev @electron-forge/publisher-s3
+```
+{% endtab %}
+
+{% tab title="Bun" %}
+```bash
+cd my-app
+bun add --dev @electron-forge/publisher-s3
 ```
 {% endtab %}
 {% endtabs %}

--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -18,6 +18,13 @@ yarn create electron-app my-new-app --template=webpack-typescript
 npm init electron-app@latest my-new-app -- --template=webpack-typescript
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app@latest my-new-app -- --template=webpack-typescript
+```
+{% endtab %}
+
 {% endtabs %}
 
 {% hint style="warning" %}

--- a/templates/vite-+-typescript.md
+++ b/templates/vite-+-typescript.md
@@ -14,6 +14,12 @@ yarn create electron-app my-new-app --template=vite-typescript
 npm init electron-app@latest my-new-app -- --template=vite-typescript
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app my-new-app --template=vite-typescript
+```
+{% endtab %}
 {% endtabs %}
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory.

--- a/templates/vite.md
+++ b/templates/vite.md
@@ -18,6 +18,12 @@ yarn create electron-app my-new-app --template=vite
 npm init electron-app@latest my-new-app -- --template=vite
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app my-new-app --template=vite
+```
+{% endtab %}
 {% endtabs %}
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory.

--- a/templates/webpack-template.md
+++ b/templates/webpack-template.md
@@ -18,6 +18,12 @@ yarn create electron-app my-new-app --template=webpack
 npm init electron-app@latest my-new-app -- --template=webpack
 ```
 {% endtab %}
+
+{% tab title="Bun" %}
+```bash
+bunx create-electron-app my-new-app --template=webpack
+```
+{% endtab %}
 {% endtabs %}
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.


### PR DESCRIPTION
Adding instructions for users who use Bun for package management & script/CLI execution (`bunx`)

Currently working on a separate PR to detect/support `bun` in `create-electron-app` as well, those both PRs are reviewable/mergable independently.