### PR TITLE
fix(debugging): use integrated terminal in VSCode

### DIFF
--- a/advanced/debugging.md
+++ b/advanced/debugging.md
@@ -35,7 +35,8 @@ If you are using &lt; 1.8 you should really be updating Electron anyway.
     "foo",
     "bar"
   ],
-  "cwd": "${workspaceFolder}"
+  "cwd": "${workspaceFolder}",
+  "console": "integratedTerminal"
 }
 ```
 {% endcode %}


### PR DESCRIPTION
Not having this option can lead to issues with the preload script for whatever reason; it can't find the file, which then causes Electron to fail to load the rest of the app. However, explicitly running it through the integrated terminal solves the problem.