### PR TITLE
chore: set language identifier to fix lint

### DIFF
--- a/guides/create-and-add-icons.md
+++ b/guides/create-and-add-icons.md
@@ -16,7 +16,7 @@ On platforms that have high-DPI support (such as Apple Retina displays), you can
 
 If you want to support different displays with different DPI densities at the same time, you can put images with different sizes in the same folder and use the filename without DPI suffixes. For example:
 
-```
+```text
 images/
 ├── icon.png
 ├── icon@2x.png


### PR DESCRIPTION
Lint rules require a language identifier. In this case it's a bit redundant since it's plain text, but lint job doesn't know that.