### PR TITLE
build: auto-fix lint issues

### DIFF
--- a/.github/workflows/auto-fix-lint.yml
+++ b/.github/workflows/auto-fix-lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - v6
       - v7
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/auto-fix-lint.yml
+++ b/.github/workflows/auto-fix-lint.yml
@@ -1,0 +1,49 @@
+name: Auto-fix Lint
+
+on:
+  push:
+    branches:
+      - v6
+      - v7
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Safeguard against creating a loop
+    if: "${{ github.event.commits[0].message != 'chore: auto-fix lint' }}"
+    steps:
+    - name: Generate GitHub App token
+      uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+      id: generate-token
+      with:
+        creds: ${{ secrets.GH_APP_CREDS }}
+        export-git-user: true
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # tag: v4.1.1
+    - name: Setup Node.js
+      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # tag: v4.0.0
+      with:
+        node-version: lts/*
+    - name: Create a Temporary package.json
+      run: npm init --yes
+    - name: Install @electron/lint-roller
+      run: npm install --save-dev @electron/lint-roller
+    - name: Run markdownlint
+      run: npx electron-markdownlint --fix "**/*.md"
+    - name: Lint JS in Markdown with standard
+      run: npx electron-lint-markdown-standard --ignore-path .markdownlintignore --semi --fix "**/*.md"
+    - name: Push Any Changes
+      run: |
+        rm -rf node_modules
+        rm -f package.json
+        rm -f package-lock.json
+        git add .
+        if test -n "$(git status -s)"; then
+          git diff --cached
+          git commit -m "chore: auto-fix lint"
+          git push origin HEAD:$GITHUB_REF
+        else
+          echo No changes to push
+        fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - v6
+      - v7
   workflow_dispatch:
     inputs:
       fetch-external-links:
@@ -18,11 +19,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # tag: v4.1.1
     - name: Setup Node.js
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # tag: v4.0.0
       with:
-        node-version: 18.x
+        node-version: lts/*
     - name: Create a Temporary package.json
       run: npm init --yes
     - name: Install @electron/lint-roller
@@ -30,10 +31,10 @@ jobs:
     - name: Run markdownlint
       run: npx electron-markdownlint "**/*.md"
     - name: Lint JS in Markdown with standard
-      run: npx electron-lint-markdown-standard --root . --ignore-path .markdownlintignore --semi --fix "**/*.md"
+      run: npx electron-lint-markdown-standard --ignore-path .markdownlintignore --semi "**/*.md"
     - name: Lint links
-      run: npx electron-lint-markdown-links --root . --ignore-path .markdownlintignore "**/*.md"
+      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore "**/*.md"
       if: ${{ always() }}
     - name: Check external links
-      run: npx electron-lint-markdown-links --root . --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
+      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
       if: ${{ github.event.inputs.fetch-external-links }}


### PR DESCRIPTION
A lot of edits come in via GitBook which means they won't get linted until they're already committed. Since many will just be minor things, try an auto-fix on new commits and commit back the result so a human doesn't need to handle the trivial stuff. This won't handle the things which can't be auto-fixed, like broken links.

This PR also updates the lint workflow and adds `v7` as a branch to look at since that's coming.