### PR TITLE
docs: update s3 maker-zip example

### DIFF
--- a/config/publishers/s3.md
+++ b/config/publishers/s3.md
@@ -78,7 +78,7 @@ module.exports = {
         // Note that we must provide this S3 URL here
         // in order to support smooth version transitions
         // especially when using a CDN to front your updates
-        macUpdateManifestBaseUrl: `https://my-bucket.s3.amazonaws.com/my-app-updates/darwin/${arch}/RELEASES.json`
+        macUpdateManifestBaseUrl: `https://my-bucket.s3.amazonaws.com/my-app-updates/darwin/${arch}`
       })
     },
     {


### PR DESCRIPTION
Current documentation is a little bit inaccurate. Maybe code was updated separately.

Looking at https://github.com/electron/forge/blob/main/packages/maker/zip/src/MakerZIP.ts#L48-L50 we can see that `/RELEASES.json` is added automatically by the library.

I understand that developers can figure this out, but we could save them (us) couple hours or hairs. :)