### PR TITLE
docs: add publish command to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Once you've got a basic app starting, building and publishing, it's time to add 
 
 You can also check out the documentation on some of our more advanced features like:
 
-- [Adding plugins](config/plugins/)
-- [Debugging your app](advanced/debugging.md)
-- [Writing your own makers, publishers and plugins](advanced/extending-electron-forge/)
+* [Adding plugins](config/plugins/)
+* [Debugging your app](advanced/debugging.md)
+* [Writing your own makers, publishers and plugins](advanced/extending-electron-forge/)

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ npm init electron-app@latest my-app -- --template=webpack
 
 There are currently four first-party templates:
 
-- `webpack`
-- `webpack-typescript`
-- `vite`
-- `vite-typescript`
+* `webpack`
+* `webpack-typescript`
+* `vite`
+* `vite-typescript`
 
 Both of these templates are built around plugins that bundle your JavaScript code for production and includes a dev server to provide a better developer experience.
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ npm init electron-app@latest my-app -- --template=webpack
 
 There are currently four first-party templates:
 
-* `webpack`
-* `webpack-typescript`
-* `vite`
-* `vite-typescript`
+- `webpack`
+- `webpack-typescript`
+- `vite`
+- `vite-typescript`
 
 Both of these templates are built around plugins that bundle your JavaScript code for production and includes a dev server to provide a better developer experience.
 
@@ -62,11 +62,19 @@ npm run make
 
 ## Publishing your app
 
-Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For more information on what publishers we currently support, check out the [Publishers](config/publishers/) documentation.
+Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For example, if you are using GitHub as a publisher, you can install it using:
+
+```bash
+npm install -D @electron-forge/publisher-github
+```
+
+And then run
 
 ```bash
 npm run publish
 ```
+
+For more information on what publishers we currently support, check out the [Publishers](config/publishers/) documentation.
 
 ## Advanced Usage
 
@@ -74,6 +82,6 @@ Once you've got a basic app starting, building and publishing, it's time to add 
 
 You can also check out the documentation on some of our more advanced features like:
 
-* [Adding plugins](config/plugins/)
-* [Debugging your app](advanced/debugging.md)
-* [Writing your own makers, publishers and plugins](advanced/extending-electron-forge/)
+- [Adding plugins](config/plugins/)
+- [Debugging your app](advanced/debugging.md)
+- [Writing your own makers, publishers and plugins](advanced/extending-electron-forge/)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run make
 
 ## Publishing your app
 
-Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For example, if you are using GitHub as a publisher, you can install it using:
+Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For example, if you want to publish your assets to GitHub, you can install it using:
 
 ```bash
 npm install -D @electron-forge/publisher-github

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Now you have distributables that you can share with your users. If you run the `
 npm install -D @electron-forge/publisher-github
 ```
 
-And then run
+And then run:
 
 ```bash
 npm run publish

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ npm run make
 
 ## Publishing your app
 
-Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For example, if you want to publish your assets to GitHub, you can install it using:
+Now you have distributables that you can share with your users. If you run the `publish` script, Electron Forge will then publish the platform-specific distributables for you, using the publishing method of your choice. For example, if you want to publish your assets to GitHub, you can install the GitHub publisher dependency using:
 
 ```bash
-npm install -D @electron-forge/publisher-github
+npm install --save-dev @electron-forge/publisher-github
 ```
 
-And then run:
+Once you have [configured the publisher according to the documentation](config/publishers/github), run the following command to upload your distributables:
 
 ```bash
 npm run publish


### PR DESCRIPTION
Updated docs to include information regarding installation of NPM packages before publishing 