### PR TITLE
Fix typo in vite.md

### DIFF
--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -68,17 +68,17 @@ module.exports = {
             "build": [
               {
                 "entry": "src/main.js",
-                "config": "vite.main.config.mjs",
+                "config": "vite.main.config.mjs"
               },
               {
                 "entry": "src/preload.js",
-                "config": "vite.preload.config.mjs",
+                "config": "vite.preload.config.mjs"
               },
             ],
             "renderer": [
               {
                 "name": "main_window",
-                "config": "vite.renderer.config.mjs",
+                "config": "vite.renderer.config.mjs"
               }
             ]
           }

--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -79,8 +79,8 @@ module.exports = {
               {
                 "name": "main_window",
                 "config": "vite.renderer.config.mjs",
-              }]
-            }
+              }
+            ]
           }
         }
       ]

--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -73,7 +73,7 @@ module.exports = {
               {
                 "entry": "src/preload.js",
                 "config": "vite.preload.config.mjs"
-              },
+              }
             ],
             "renderer": [
               {


### PR DESCRIPTION
Hey, thank you for your project.

It seems that there is a typo into the code example there (an extra `}`)