### PR TITLE
ci: fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,14 +27,14 @@ jobs:
     - name: Create a Temporary package.json
       run: npm init --yes
     - name: Install @electron/lint-roller
-      run: npm install --save-dev @electron/lint-roller
+      run: npm install --save-dev @electron/lint-roller@^2.1.0
     - name: Run markdownlint
       run: npx electron-markdownlint "**/*.md"
     - name: Lint JS in Markdown with standard
-      run: npx electron-lint-markdown-standard --ignore-path .markdownlintignore --semi "**/*.md"
+      run: npx lint-roller-markdown-standard --ignore-path .markdownlintignore --semi "**/*.md"
     - name: Lint links
-      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore "**/*.md"
+      run: npx lint-roller-markdown-links --ignore-path .markdownlintignore "**/*.md"
       if: ${{ always() }}
     - name: Check external links
       run: npx electron-lint-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
-      if: ${{ github.event.inputs.fetch-external-links }}
+      if: ${{ inputs.fetch-external-links }}


### PR DESCRIPTION
Fixing the breaking change from `@electron/lint-roller` v2, since this workflow wasn't pinning to a particular version.

Also fixes usage of the boolean input for fetch external links, it was previously always running since `github.event.inputs.fetch-external-links` converts the boolean to a string, but `inputs.fetch-external-links` does not.