### PR TITLE
fix(makers): `config` can also be a function

### DIFF
--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -11,6 +11,28 @@ Makers are Electron Forge's way of taking your packaged application and making p
 Each maker has to be configured in the `makers` section of your forge configuration with which platforms to run for and the maker specific config. E.g.
 
 {% tabs %}
+{% tab title="forge.config.js" %}
+```javascript
+module.exports = {
+  makers: [
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin', 'linux'],
+      config: {
+        // the config is an object containing optios
+      }
+    },
+    {
+      name: '@electron-forge/maker-dmg',
+      platforms: ['darwin'],
+      config: (arch) => ({
+        // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
+      })
+    }
+  ]
+};
+```
+{% endtab %}
 {% tab title="package.json" %}
 ```jsonc
 // If your config is only in package.json:
@@ -30,29 +52,6 @@ Each maker has to be configured in the `makers` section of your forge configurat
     }
   }
 }
-```
-{% endtab %}
-
-{% tab title="forge.config.js" %}
-```javascript
-module.exports = {
-  makers: [
-    {
-      name: '@electron-forge/maker-zip',
-      platforms: ['darwin', 'linux'],
-      config: {
-        // 
-      }
-    },
-    {
-      name: '@electron-forge/maker-dmg',
-      platforms: ['darwin'],
-      config: (arch) => ({
-        // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
-      })
-    }
-  ]
-};
 ```
 {% endtab %}
 {% endtabs %}

--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -19,14 +19,14 @@ module.exports = {
       name: '@electron-forge/maker-zip',
       platforms: ['darwin', 'linux'],
       config: {
-        // the config is an object containing optios
+        // the config can be an object
       }
     },
     {
       name: '@electron-forge/maker-dmg',
-      platforms: ['darwin'],
       config: (arch) => ({
-        // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
+        // it can also be a function taking the currently built arch
+        // as a parameter and returning a config object, e.g.
       })
     }
   ]

--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -44,7 +44,11 @@ module.exports = {
       platforms: ['darwin', 'linux'],
       config: {
         // Config here
-      }
+      } 
+      // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
+      //config: (arch) => ({
+      // ...
+      //})
     }
   ]
 };

--- a/config/makers/README.md
+++ b/config/makers/README.md
@@ -35,20 +35,21 @@ Each maker has to be configured in the `makers` section of your forge configurat
 
 {% tab title="forge.config.js" %}
 ```javascript
-// If you have set config.forge to a JavaScript file path in package.json:
-// Only showing the relevant configuration for brevity
 module.exports = {
   makers: [
     {
       name: '@electron-forge/maker-zip',
       platforms: ['darwin', 'linux'],
       config: {
-        // Config here
-      } 
-      // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
-      //config: (arch) => ({
-      // ...
-      //})
+        // 
+      }
+    },
+    {
+      name: '@electron-forge/maker-dmg',
+      platforms: ['darwin'],
+      config: (arch) => ({
+        // can also be a function taking the currently built arch as a parameter and returning a config object, e.g.
+      })
     }
   ]
 };


### PR DESCRIPTION
A maker's config key can be a function but that is not well documented. This adds the necessary information to the `forge.config.js` example in the makers section.