### PR TITLE
docs: add yarn command to create electron-app

### DIFF
--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -6,8 +6,16 @@ description: Create a new Electron app with webpack and TypeScript.
 
 To get you up and running as fast as possible with [TypeScript](https://www.typescriptlang.org/) and [webpack](https://webpack.js.org/), we provide a template that makes use of the [`@electron-forge/plugin-webpack` module](../config/plugins/webpack.md) with sane TypeScript configuration defaults.
 
+With npm:
+
 ```bash
 npm init electron-app@latest my-new-app -- --template=webpack-typescript
+```
+
+With yarn:
+
+```bash
+yarn create electron-app my-new-app --template=webpack-typescript
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
# Changes

Added yarn to docs, as I was having a bit struggle to understand why I got 129 error while using it. Turns out when you use yarn, you can't specify version (`@latest`), so you use just package name to get latest one. Also abandoned `--` as from Yarn 1.0 it's not required.