### PR TITLE
vite.md: faulty documentation

### DIFF
--- a/config/plugins/vite.md
+++ b/config/plugins/vite.md
@@ -122,24 +122,7 @@ If using the Vite template, this should be automatically set up for you.
 
 ### Native Node modules
 
-If you used the [Vite](../../templates/vite.md) template to create your application, native modules will mostly work out of the box. However, to avoid possible build issues, we recommend instructing Vite to load them as external packages:
-
-{% code title="vite.main.config.js" %}
-```javascript
-import { defineConfig } from 'vite';
-
-export default defineConfig({
-  build: {
-    rollupOptions: {
-      external: [
-        'serialport',
-        'sqlite3'
-      ]
-    }
-  }
-});
-```
-{% endcode %}
+If you used the [Vite](../../templates/vite.md) template to create your application, native modules will mostly work out of the box. However, we recommend copying external dependencies also to avoid possible build issues.
 
 ### Hot Module Replacement (HMR)
 


### PR DESCRIPTION
The latest version of the Vite plugin will not copy external dependencies. The documentation is outdated and will confuse users.