### PR TITLE
Add missing import in example

### DIFF
--- a/config/typescript-configuration.md
+++ b/config/typescript-configuration.md
@@ -68,6 +68,7 @@ For example, the below configuration is equivalent to the `makers` array from th
 ```typescript
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerDeb } from '@electron-forge/maker-deb';
+import { MakerRpm } from '@electron-forge/maker-rpm';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
 


### PR DESCRIPTION
Import of `MakerRpm` is missing