### PR TITLE
fix: change `npm init` commands for `npx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Electron Forge currently only supports npm and Yarn Classic. If you are using Ya
 {% endhint %}
 
 ```bash
-npm init electron-app@latest my-app
+npx create-electron-app@latest my-app
 ```
 
 ### Using templates
@@ -25,7 +25,7 @@ npm init electron-app@latest my-app
 Forge's initialization scripts can add additional template code with the `--template=[template-name]` flag.
 
 ```bash
-npm init electron-app@latest my-app -- --template=webpack
+npx create-electron-app@latest my-app --template=webpack
 ```
 
 There are currently four first-party templates:

--- a/guides/framework-integration/vue-3.md
+++ b/guides/framework-integration/vue-3.md
@@ -17,7 +17,7 @@ The following guide has been tested with Vue 3 and Vite 4.
 Create an Electron app using Electron Forge's [Vite](../../templates/vite.md) template.
 
 ```bash
-npm init electron-app@latest my-vue-app -- --template=vite
+npx create-electron-app@latest my-vue-app --template=vite
 ```
 
 ## Adding dependencies

--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -7,7 +7,7 @@ description: Create a new Electron app with webpack and TypeScript.
 To get you up and running as fast as possible with [TypeScript](https://www.typescriptlang.org/) and [webpack](https://webpack.js.org/), we provide a template that makes use of the [`@electron-forge/plugin-webpack` module](../config/plugins/webpack.md) with sane TypeScript configuration defaults.
 
 ```bash
-npm init electron-app@latest my-new-app -- --template=webpack-typescript
+npx create-electron-app@latest my-new-app --template=webpack-typescript
 ```
 
 {% hint style="warning" %}

--- a/templates/vite-+-typescript.md
+++ b/templates/vite-+-typescript.md
@@ -9,7 +9,7 @@ For more context, see the Electron Forge [v7.5.0 release notes](https://github.c
 To get you up and running as fast as possible with [TypeScript](https://www.typescriptlang.org/) and [Vite](https://vitejs.dev/), we provide a template that makes use of the [`@electron-forge/plugin-vite` module](../config/plugins/vite.md) with sane TypeScript configuration defaults.
 
 ```bash
-npm init electron-app@latest my-new-app -- --template=vite-typescript
+npx create-electron-app@latest my-new-app --template=vite-typescript
 ```
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory.

--- a/templates/vite.md
+++ b/templates/vite.md
@@ -13,7 +13,7 @@ For more context, see the Electron Forge [v7.5.0 release notes](https://github.c
 To get you up and running as fast as possible with [Vite](https://vitejs.dev/), we provide a template that makes use of the [`@electron-forge/plugin-vite` module](../config/plugins/vite.md), plus some preset Vite configuration options.
 
 ```bash
-npm init electron-app@latest my-new-app -- --template=vite
+npx create-electron-app@latest my-new-app --template=vite
 ```
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory.

--- a/templates/webpack-template.md
+++ b/templates/webpack-template.md
@@ -7,7 +7,7 @@ description: Create a new Electron app with Webpack
 To get you up and running as fast as possible with the [webpack](https://webpack.js.org) bundler, we provide a template that makes use of the [`@electron-forge/plugin-webpack` module](../config/plugins/webpack.md), plus some preset webpack configuration options.  This is by far the quickest way to getting a working webpack setup with Electron.
 
 ```bash
-npm init electron-app@latest my-new-app -- --template=webpack
+npx create-electron-app@latest my-new-app --template=webpack
 ```
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3662

I'm not sure why `npm init` isn't passing flags into Windows, but this alternative syntax is working for me on macOS at least. Will need someone else to test on Windows today.