### PR TITLE
docs: fix import path

### DIFF
--- a/guides/code-signing/code-signing-windows.md
+++ b/guides/code-signing/code-signing-windows.md
@@ -153,7 +153,7 @@ In your `forge.config.ts`, add the following:
 {% code title="forge.config.ts" %}
 ```typescript
 // Add import:
-import { windowsSign } from "./src/util/windowsSign";
+import { windowsSign } from "./windowsSign";
 
 const config: ForgeConfig = {
   packagerConfig: {


### PR DESCRIPTION
I noticed this after I reviewed the merged docs on the [live site](https://www.electronforge.io/guides/code-signing/code-signing-windows).

Looks like I had copied the import from my own project and not adjusted it to match the rest of the instructions. Sorry!