### PR TITLE
Warning and workaround for error in electron

### DIFF
--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -15,3 +15,5 @@ There have been reports that using the Git Bash command line on Windows specific
 {% endhint %}
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.
+
+Note: Executing `npm start` immediately after creating the app will reliably produce two errors due to [an issue with electron](https://github.com/electron/electron/issues/41614)that is currently marked as "wontfix." The appropriate solution for you depends on your specific app, but a temporary fix can be performed with two changes to `main.js`. First, comment out line 23 (`mainWindow.webContents.openDevTools()`), second, add `app.disableHardwareAcceleration()` at the end of the file.

--- a/templates/typescript-+-webpack-template.md
+++ b/templates/typescript-+-webpack-template.md
@@ -15,5 +15,3 @@ There have been reports that using the Git Bash command line on Windows specific
 {% endhint %}
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.
-
-Note: Executing `npm start` immediately after creating the app will reliably produce two errors due to [an issue with electron](https://github.com/electron/electron/issues/41614)that is currently marked as "wontfix." The appropriate solution for you depends on your specific app, but a temporary fix can be performed with two changes to `main.js`. First, comment out line 23 (`mainWindow.webContents.openDevTools()`), second, add `app.disableHardwareAcceleration()` at the end of the file.

--- a/templates/webpack-template.md
+++ b/templates/webpack-template.md
@@ -13,5 +13,5 @@ npx create-electron-app@latest my-new-app --template=webpack
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.
 
 {% hint style="warning" %}
-Executing `npm start` immediately after creating the app will reliably produce two errors due to [an issue with electron](https://github.com/electron/electron/issues/41614)that is currently marked as "wontfix." The appropriate solution for you depends on your specific app, but a temporary fix can be performed with two changes to `main.js`. First, comment out line 23 (`mainWindow.webContents.openDevTools()`), second, add `app.disableHardwareAcceleration()` at the end of the file.
+Executing `npm start` immediately after creating the app will reliably produce two errors due to [an issue with electron](https://github.com/electron/electron/issues/41614)that is currently marked as "wontfix." A temporary fix for one of the errors can be performed by commenting out line 23 (`mainWindow.webContents.openDevTools()`) until you have found a solution that is appropriate with your specific app.
 {% endhint %}

--- a/templates/webpack-template.md
+++ b/templates/webpack-template.md
@@ -11,3 +11,7 @@ npx create-electron-app@latest my-new-app --template=webpack
 ```
 
 Once you've initialized the template, you'll need to run `npm start` in the generated directory. See the [Webpack Plugin](../config/plugins/webpack.md) documentation for Electron Forge-specific configuration options.
+
+{% hint style="warning" %}
+Executing `npm start` immediately after creating the app will reliably produce two errors due to [an issue with electron](https://github.com/electron/electron/issues/41614)that is currently marked as "wontfix." The appropriate solution for you depends on your specific app, but a temporary fix can be performed with two changes to `main.js`. First, comment out line 23 (`mainWindow.webContents.openDevTools()`), second, add `app.disableHardwareAcceleration()` at the end of the file.
+{% endhint %}


### PR DESCRIPTION
Electron has a wontfix error that impacts the webpack template workflow.

This PR adds a warning to the docs, and a suggested workaround.