### PR TITLE
docs(config): document extraResource for runtime assets

### DIFF
--- a/config/configuration.md
+++ b/config/configuration.md
@@ -123,6 +123,33 @@ If you want to specify a platform/architecture combination for any build command
 See the [#build-commands](../cli.md#build-commands "mention") documentation for more details.
 {% endhint %}
 
+{% hint style="info" %}
+To ship runtime assets that live outside your bundled source code (for example, a tray icon or other binary file referenced at runtime), use [`extraResource`](https://electron.github.io/packager/main/interfaces/Options.html#extraresource). Files listed here are copied into the platform's resources directory (next to `app.asar`) and are available at runtime via `process.resourcesPath`.
+
+{% code title="forge.config.js" %}
+```javascript
+module.exports = {
+  packagerConfig: {
+    extraResource: ['./assets/tray-icon.png']
+  }
+};
+```
+{% endcode %}
+
+In the main process, resolve the file with `process.resourcesPath` when the app is packaged:
+
+```javascript
+const path = require('path');
+const { app, Tray } = require('electron');
+
+const iconPath = app.isPackaged
+  ? path.join(process.resourcesPath, 'tray-icon.png')
+  : path.join(__dirname, '..', 'assets', 'tray-icon.png');
+
+const tray = new Tray(iconPath);
+```
+{% endhint %}
+
 ### Electron Rebuild config
 
 The top level property `rebuildConfig` on the configuration object maps directly to the options sent to [`@electron/rebuild`](https://github.com/electron/rebuild) during both the [#package](../cli.md#package "mention") and [#start](../cli.md#start "mention") commands in Electron Forge.


### PR DESCRIPTION
Refs electron/forge#3621.

The Electron Packager config page lists `packagerConfig` and links to the Packager API docs, but does not show how to ship runtime assets (e.g. a tray icon, native binary, or other file referenced at runtime). Issue #3621 is exactly this case: a tray icon loads in `electron-forge start` but fails after packaging because the file is inside `app.asar`. The fix is `extraResource` plus `process.resourcesPath`, which is non-obvious without prior knowledge.

Adds a hint block under the `Electron Packager config` section with a minimal `extraResource` example and the matching tray-icon main-process snippet that resolves the path with `process.resourcesPath` when `app.isPackaged`.

Maintainer endorsement on the issue (after a contributor offered to write this doc):
> Hi @vishalkishore, PRs welcome in https://github.com/electron-forge/electron-forge-docs
>
> -- @erickzhao, https://github.com/electron/forge/issues/3621#issuecomment-2730492124